### PR TITLE
[Fix] Launch basics

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Prevent accidental publishes to public npm registry
+# This package uses PROPRIETARY license — internal use only
+publish-registry=https://npm.pkg.github.com
+access=restricted


### PR DESCRIPTION
Add .npmrc to prevent accidental public npm publish (PROPRIETARY license)