### PR TITLE
[Fix] Normalize wendermedia.com URLs to www

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ Output formats:
 
 - Open an [issue](https://github.com/arnoldwender/wm-project-astro-components/issues)
 - Email: arnold.wender@gmail.com
-- Website: [wendermedia.com](https://wendermedia.com)
+- Website: [wendermedia.com](https://www.wendermedia.com)
 
 ## License
 

--- a/OPEN-SOURCE-REPORT.md
+++ b/OPEN-SOURCE-REPORT.md
@@ -22,7 +22,7 @@ The `wm-project-astro-components` repository has been fully prepared for open-so
 | **Legal Name** | Wender Media - Arnold Wender |
 | **Founded** | 2007 |
 | **Location** | Halle (Saale), Germany |
-| **Website** | [wendermedia.com](https://wendermedia.com) |
+| **Website** | [wendermedia.com](https://www.wendermedia.com) |
 | **Author** | Arnold Wender |
 | **Author Website** | [arnoldwender.com](https://arnoldwender.com) |
 | **GitHub** | [@arnoldwender](https://github.com/arnoldwender) |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://wendermedia.com/favicon.svg" alt="WenderMedia Logo" width="64" height="64" />
+  <img src="https://www.wendermedia.com/favicon.svg" alt="WenderMedia Logo" width="64" height="64" />
 </p>
 
 <h1 align="center">@wendermedia/astro-components</h1>
 
 <p align="center">
   <strong>150+ production-ready, accessible, GDPR-compliant Astro components</strong><br />
-  Built by <a href="https://wendermedia.com">Wender Media</a> &mdash; Web Agency from Halle (Saale), Germany
+  Built by <a href="https://www.wendermedia.com">Wender Media</a> &mdash; Web Agency from Halle (Saale), Germany
 </p>
 
 <p align="center">
@@ -391,7 +391,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for release history.
 
 **Arnold Wender**
 - Website: [arnoldwender.com](https://arnoldwender.com)
-- Agency: [Wender Media](https://wendermedia.com) - Web Agency, Halle (Saale), Germany
+- Agency: [Wender Media](https://www.wendermedia.com) - Web Agency, Halle (Saale), Germany
 - GitHub: [@arnoldwender](https://github.com/arnoldwender)
 - Twitter/X: [@arnoldwender](https://x.com/arnoldwender)
 - LinkedIn: [arnoldwender](https://linkedin.com/in/arnoldwender)
@@ -400,10 +400,10 @@ See [CHANGELOG.md](./CHANGELOG.md) for release history.
 
 This project is licensed under the [MIT License](./LICENSE).
 
-Copyright (c) 2007-2026 [Wender Media](https://wendermedia.com) - Arnold Wender.
+Copyright (c) 2007-2026 [Wender Media](https://www.wendermedia.com) - Arnold Wender.
 
 ---
 
 <p align="center">
-  Made with care by <a href="https://wendermedia.com">Wender Media</a> in Halle (Saale), Germany
+  Made with care by <a href="https://www.wendermedia.com">Wender Media</a> in Halle (Saale), Germany
 </p>

--- a/public/colophon.html
+++ b/public/colophon.html
@@ -223,7 +223,7 @@
 
     <h2>📞 Credits</h2>
     <p>
-      <strong>Created by:</strong> Arnold Wender - <a href="https://wendermedia.com">Wender Media</a><br>
+      <strong>Created by:</strong> Arnold Wender - <a href="https://www.wendermedia.com">Wender Media</a><br>
       <strong>GitHub:</strong> <a href="https://github.com/arnoldwender/wm-project-astro-components">arnoldwender/wm-project-astro-components</a><br>
       <strong>Website:</strong> <a href="https://www.wendermedia.com">wendermedia.com</a>
     </p>

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -4,7 +4,7 @@
 # TEAM
 
     Arnold Wender -- Creator -- https://arnoldwender.com
-    Wender Media -- Web Agency -- https://wendermedia.com
+    Wender Media -- Web Agency -- https://www.wendermedia.com
 
 # THANKS
 


### PR DESCRIPTION
All wendermedia.com links now consistently use https://www.wendermedia.com. arnoldwender.com stays without www.