### PR TITLE
[Docs] Fix llms.txt license and CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to @wendermedia/astro-components will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2025-01-XX
+## [2.0.0] - 2026-04-06
 
 ### Added
 

--- a/llms.txt
+++ b/llms.txt
@@ -57,4 +57,4 @@
 
 ## License
 
-PROPRIETARY — WenderMedia internal use only.
+MIT License — Copyright (c) 2007-2026 Wender Media - Arnold Wender.


### PR DESCRIPTION
Final docs fix: llms.txt PROPRIETARY -> MIT, CHANGELOG date -> 2026-04-06.