### PR TITLE
[Fix] Use company email for public contact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ Output formats:
 ## Questions?
 
 - Open an [issue](https://github.com/arnoldwender/wm-project-astro-components/issues)
-- Email: arnold.wender@gmail.com
+- Email: info@wendermedia.com
 - Website: [wendermedia.com](https://www.wendermedia.com)
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 **Please DO NOT create public GitHub issues for security vulnerabilities.**
 
-1. **Email**: arnold.wender@gmail.com
+1. **Email**: info@wendermedia.com
 2. **Subject**: `[SECURITY] Brief description of the issue`
 
 ### What to Include
@@ -60,7 +60,7 @@ We monitor dependencies for known vulnerabilities:
 
 ## Contact
 
-**Email**: arnold.wender@gmail.com
+**Email**: info@wendermedia.com
 **Website**: https://www.wendermedia.com
 
 ---

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "wordpress",
     "headless-cms"
   ],
-  "author": "Arnold Wender <arnold.wender@gmail.com>",
+  "author": "Arnold Wender <info@wendermedia.com> (https://www.wendermedia.com)",
   "license": "MIT",
   "homepage": "https://github.com/arnoldwender/wm-project-astro-components#readme",
   "repository": {


### PR DESCRIPTION
Replace personal Gmail with info@wendermedia.com in package.json, SECURITY.md, CONTRIBUTING.md.