### PR TITLE
[Fix] Expose ui + layouts in exports — v4.0.1 (36 unreachable components)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,12 @@
 /**
  * WenderMedia Astro Components
- * Complete component library for Astro 6 projects with SEO optimization
+ * Complete component library for Astro 7 projects with SEO optimization
  *
  * @package @wendermedia/astro-components
  * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved.
  * @license LicenseRef-Wender-Media-Source-1.0
  * @see https://github.com/arnoldwender/wm-project-astro-components
- * @version 3.0.1
+ * @version 4.0.1
  */
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete Astro 7 development resource - components, bundles, integrations, and utilities",
   "type": "module",
   "main": "./index.ts",
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./index.ts",
     "./layout": "./src/layout/index.ts",
+    "./layouts": "./src/layouts/index.ts",
     "./seo": "./src/seo/index.ts",
     "./accessibility": "./src/accessibility/index.ts",
     "./sections": "./src/sections/index.ts",
@@ -25,6 +26,7 @@
     "./content": "./src/content/index.ts",
     "./ecommerce": "./src/ecommerce/index.ts",
     "./media": "./src/media/index.ts",
+    "./ui": "./src/ui/index.ts",
     "./design-system": "./src/design-system/index.ts",
     "./design-system/tokens/*": "./src/design-system/tokens/*",
     "./design-system/base/*": "./src/design-system/base/*",


### PR DESCRIPTION
## Problem

`ui` (21 components) and `layouts` (15) ship barrels (`src/ui/index.ts`, `src/layouts/index.ts`) but are **absent from `package.json` `exports`** and not re-exported from root `index.ts`. Node/Vite exports maps are restrictive → **36 of 183 components are unreachable by any consumer** (`import { Modal } from '@wendermedia/astro-components/ui'` fails). The library advertises 183 but only 147 are importable.

## Fix

- Add `./ui` and `./layouts` subpath exports (consistent with the other 16 category barrels).
- Bump `4.0.0` → `4.0.1`.
- Fix stale `@version 3.0.1` / "Astro 6" docstring in root `index.ts`.

## Impact

Unblocks all 183 components for consumers (e.g. wm-project-astro-builder registry). No breaking changes — purely additive.