### PR TITLE
[Fix] Remove license banner mis-injected into 12 component templates (v4.0.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Complete Astro 7 development resource - components, bundles, integrations, and utilities",
   "type": "module",
   "main": "./index.ts",

--- a/src/content/ShareBar.astro
+++ b/src/content/ShareBar.astro
@@ -257,8 +257,6 @@ const sizeClasses = {
     font-weight: 500;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Toast */
   .share-toast {
     position: fixed;

--- a/src/ecommerce/AddToCartButton.astro
+++ b/src/ecommerce/AddToCartButton.astro
@@ -149,8 +149,6 @@ const {
     flex: 1;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Quantity Controls */
   .add-to-cart__quantity {
     display: flex;
@@ -209,8 +207,6 @@ const {
     -webkit-appearance: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Button */
   .add-to-cart__btn {
     position: relative;
@@ -226,8 +222,6 @@ const {
     overflow: hidden;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Sizes */
   .add-to-cart--sm .add-to-cart__btn {
     padding: 0.5rem 1rem;
@@ -244,8 +238,6 @@ const {
     font-size: 1rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Variants */
   .add-to-cart--primary .add-to-cart__btn {
     background: var(--atc-primary);
@@ -276,8 +268,6 @@ const {
     color: var(--atc-text);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Icons */
   .add-to-cart__icon,
   .add-to-cart__check {
@@ -302,8 +292,6 @@ const {
     display: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Spinner */
   .add-to-cart__spinner {
     display: none;
@@ -319,8 +307,6 @@ const {
     to { transform: rotate(360deg); }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* States */
   .add-to-cart__added {
     display: none;

--- a/src/ecommerce/Cart.astro
+++ b/src/ecommerce/Cart.astro
@@ -229,8 +229,6 @@ const {
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Toggle Button */
   .cart-toggle {
     position: relative;
@@ -271,8 +269,6 @@ const {
     border-radius: 9999px;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Drawer */
   .cart-drawer {
     position: fixed;
@@ -332,8 +328,6 @@ const {
     to { transform: translateX(0); }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Header */
   .cart-drawer__header {
     display: flex;
@@ -376,8 +370,6 @@ const {
     height: 1.25rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Shipping Progress */
   .shipping-progress__text {
     padding: 0.75rem 1.5rem;
@@ -401,8 +393,6 @@ const {
     transition: width 0.3s ease;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Items Container */
   .cart-drawer__items {
     flex: 1;
@@ -410,8 +400,6 @@ const {
     padding: 1rem 1.5rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Empty State */
   .cart-drawer__empty {
     display: flex;
@@ -456,8 +444,6 @@ const {
     color: var(--color-white, #fff);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Cart Item */
   .cart-item {
     display: grid;
@@ -581,8 +567,6 @@ const {
     height: 1rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Footer */
   .cart-drawer__footer {
     padding: 1rem 1.5rem;

--- a/src/ecommerce/ProductCard.astro
+++ b/src/ecommerce/ProductCard.astro
@@ -153,8 +153,6 @@ const productSchema = {
       )}
     </a>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Badge */}
     {badge && (
       <span class:list={['product-card__badge', `product-card__badge--${badgeVariant}`]}>
@@ -162,8 +160,6 @@ const productSchema = {
       </span>
     )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Discount Badge */}
     {discount > 0 && !badge && (
       <span class="product-card__badge product-card__badge--sale">
@@ -171,8 +167,6 @@ const productSchema = {
       </span>
     )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Out of Stock Overlay */}
     {!inStock && (
       <div class="product-card__out-of-stock">
@@ -180,8 +174,6 @@ const productSchema = {
       </div>
     )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Actions */}
     <div class="product-card__actions">
       {showWishlist && (
@@ -237,8 +229,6 @@ const productSchema = {
       <a href={url}>{name}</a>
     </h3>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Rating */}
     {rating && (
       <div class="product-card__rating" aria-label={`${rating} von 5 Sternen`}>
@@ -253,8 +243,6 @@ const productSchema = {
       </div>
     )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Price */}
     <div class="product-card__price">
       <span class="product-card__current-price">{formattedPrice}</span>
@@ -263,8 +251,6 @@ const productSchema = {
       )}
     </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Add to Cart */}
     {showAddToCart && inStock && (
       <button
@@ -321,8 +307,6 @@ const productSchema = {
     box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.12));
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Image Container */
   .product-card__image-container {
     position: relative;
@@ -359,8 +343,6 @@ const productSchema = {
     transform: scale(1.05);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Badge */
   .product-card__badge {
     position: absolute;
@@ -390,8 +372,6 @@ const productSchema = {
     background: var(--color-accent, #8b5cf6);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Out of Stock */
   .product-card--out-of-stock .product-card__image {
     opacity: 0.6;
@@ -409,8 +389,6 @@ const productSchema = {
     z-index: 2;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Actions */
   .product-card__actions {
     position: absolute;
@@ -468,8 +446,6 @@ const productSchema = {
     display: block;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Content */
   .product-card__content {
     padding: 1rem;
@@ -506,8 +482,6 @@ const productSchema = {
     color: var(--pc-primary);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Rating */
   .product-card__rating {
     display: flex;
@@ -531,8 +505,6 @@ const productSchema = {
     color: var(--pc-muted);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Price */
   .product-card__price {
     display: flex;
@@ -553,8 +525,6 @@ const productSchema = {
     text-decoration: line-through;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Add to Cart Button */
   .product-card__add-cart {
     display: flex;
@@ -583,8 +553,6 @@ const productSchema = {
     height: 1.125rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Touch devices - always show actions */
   @media (hover: none) {
     .product-card__actions {

--- a/src/ecommerce/ProductQuickView.astro
+++ b/src/ecommerce/ProductQuickView.astro
@@ -191,8 +191,6 @@ const {
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Backdrop */
   .quickview__backdrop {
     position: fixed;
@@ -211,8 +209,6 @@ const {
     to { opacity: 1; }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Modal */
   .quickview__modal {
     position: fixed;
@@ -245,8 +241,6 @@ const {
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Close Button */
   .quickview__close {
     position: absolute;
@@ -277,8 +271,6 @@ const {
     height: 1.25rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Content Layout */
   .quickview__content {
     display: grid;
@@ -293,8 +285,6 @@ const {
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Gallery */
   .quickview__gallery {
     padding: 1.5rem;
@@ -344,8 +334,6 @@ const {
     object-fit: cover;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Product Info */
   .quickview__info {
     padding: 2rem;
@@ -374,8 +362,6 @@ const {
     color: var(--qv-muted);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Variants */
   .quickview__variants {
     display: flex;
@@ -422,8 +408,6 @@ const {
     color: #fff;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Quantity */
   .quickview__quantity {
     display: flex;
@@ -475,8 +459,6 @@ const {
     -webkit-appearance: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Actions */
   .quickview__actions {
     display: flex;
@@ -546,8 +528,6 @@ const {
     display: block;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* View Product Link */
   .quickview__view-product {
     display: inline-flex;

--- a/src/ecommerce/Wishlist.astro
+++ b/src/ecommerce/Wishlist.astro
@@ -176,8 +176,6 @@ const isCount = mode === 'count';
 )}
 
 <style>
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Toggle Button */
   .wishlist-toggle {
     display: flex;
@@ -221,8 +219,6 @@ const isCount = mode === 'count';
     50% { transform: scale(1.2); }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Count Badge */
   .wishlist-count {
     display: inline-flex;
@@ -242,8 +238,6 @@ const isCount = mode === 'count';
     display: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* List Container */
   .wishlist-list {
     --wishlist-bg: var(--color-bg, #fff);
@@ -263,8 +257,6 @@ const isCount = mode === 'count';
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Empty State */
   .wishlist-list__empty {
     display: flex;
@@ -287,8 +279,6 @@ const isCount = mode === 'count';
     opacity: 0.5;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Items Grid */
   .wishlist-list__items {
     display: grid;
@@ -296,8 +286,6 @@ const isCount = mode === 'count';
     gap: 1.5rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Wishlist Item */
   .wishlist-item {
     position: relative;
@@ -426,8 +414,6 @@ const isCount = mode === 'count';
     height: 1.25rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* List Actions */
   .wishlist-list__actions {
     display: flex;

--- a/src/images/OptimizedImage.astro
+++ b/src/images/OptimizedImage.astro
@@ -150,8 +150,6 @@ const containerStyle = [blurStyle, aspectStyle].filter(Boolean).join(' ');
   style={containerStyle || undefined}
   data-optimized-image
 >
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* AVIF source - best compression, newest format */}
   {avifSrcset && (
     <source
@@ -161,8 +159,6 @@ const containerStyle = [blurStyle, aspectStyle].filter(Boolean).join(' ');
     />
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* WebP source - good compression, wide support */}
   {webpSrcset && (
     <source
@@ -172,8 +168,6 @@ const containerStyle = [blurStyle, aspectStyle].filter(Boolean).join(' ');
     />
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Fallback image */}
   <img
     src={src}
@@ -208,8 +202,6 @@ const containerStyle = [blurStyle, aspectStyle].filter(Boolean).join(' ');
     height: 100%;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Blur placeholder animation */
   .optimized-image.has-placeholder .optimized-image-img {
     opacity: 0;

--- a/src/media/AudioPlayer.astro
+++ b/src/media/AudioPlayer.astro
@@ -86,8 +86,6 @@ const hasMultipleTracks = tracks.length > 1;
   data-autoplay={autoplay}
   data-loop={loop}
 >
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Hidden audio element */}
   <audio
     preload={preload}
@@ -97,19 +95,13 @@ const hasMultipleTracks = tracks.length > 1;
     Ihr Browser unterstützt kein Audio.
   </audio>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Track Data */}
   <script type="application/json" data-tracks>
     {JSON.stringify(tracks)}
   </script>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Player UI */}
   <div class="audio-player__main">
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Cover Art */}
     <div class="audio-player__cover" data-cover>
       {tracks[0]?.cover ? (
@@ -124,12 +116,8 @@ const hasMultipleTracks = tracks.length > 1;
       )}
     </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Track Info & Controls */}
     <div class="audio-player__content">
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Track Info */}
       <div class="audio-player__info">
         <h3 class="audio-player__title" data-title>{tracks[0]?.title}</h3>
@@ -138,8 +126,6 @@ const hasMultipleTracks = tracks.length > 1;
         )}
       </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Progress Bar */}
       <div class="audio-player__progress">
         <span class="audio-player__time" data-current-time>0:00</span>
@@ -159,12 +145,8 @@ const hasMultipleTracks = tracks.length > 1;
         <span class="audio-player__time" data-duration>0:00</span>
       </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Controls */}
       <div class="audio-player__controls">
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Previous (if playlist) */}
         {hasMultipleTracks && (
           <button
@@ -180,8 +162,6 @@ const hasMultipleTracks = tracks.length > 1;
           </button>
         )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Rewind 10s */}
         <button
           type="button"
@@ -195,8 +175,6 @@ const hasMultipleTracks = tracks.length > 1;
           </svg>
         </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Play/Pause */}
         <button
           type="button"
@@ -213,8 +191,6 @@ const hasMultipleTracks = tracks.length > 1;
           </svg>
         </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Forward 10s */}
         <button
           type="button"
@@ -228,8 +204,6 @@ const hasMultipleTracks = tracks.length > 1;
           </svg>
         </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Next (if playlist) */}
         {hasMultipleTracks && (
           <button
@@ -245,8 +219,6 @@ const hasMultipleTracks = tracks.length > 1;
           </button>
         )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Speed */}
         <button
           type="button"
@@ -257,8 +229,6 @@ const hasMultipleTracks = tracks.length > 1;
           1x
         </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Volume */}
         <div class="audio-player__volume">
           <button
@@ -291,8 +261,6 @@ const hasMultipleTracks = tracks.length > 1;
     </div>
   </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Playlist */}
   {hasMultipleTracks && showPlaylist && (
     <div class="audio-player__playlist">
@@ -354,8 +322,6 @@ const hasMultipleTracks = tracks.length > 1;
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Main Player */
   .audio-player__main {
     display: flex;
@@ -363,8 +329,6 @@ const hasMultipleTracks = tracks.length > 1;
     padding: 1rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Cover Art */
   .audio-player__cover {
     flex-shrink: 0;
@@ -395,8 +359,6 @@ const hasMultipleTracks = tracks.length > 1;
     height: 2.5rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Content */
   .audio-player__content {
     flex: 1;
@@ -406,8 +368,6 @@ const hasMultipleTracks = tracks.length > 1;
     min-width: 0;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Track Info */
   .audio-player__info {
     display: flex;
@@ -434,8 +394,6 @@ const hasMultipleTracks = tracks.length > 1;
     text-overflow: ellipsis;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Progress Bar */
   .audio-player__progress {
     display: flex;
@@ -494,8 +452,6 @@ const hasMultipleTracks = tracks.length > 1;
     z-index: 3;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Controls */
   .audio-player__controls {
     display: flex;
@@ -582,8 +538,6 @@ const hasMultipleTracks = tracks.length > 1;
     display: block;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Volume */
   .audio-player__volume {
     display: flex;
@@ -610,8 +564,6 @@ const hasMultipleTracks = tracks.length > 1;
     cursor: pointer;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Playlist */
   .audio-player__playlist {
     border-top: 1px solid var(--ap-border);
@@ -721,8 +673,6 @@ const hasMultipleTracks = tracks.length > 1;
     color: var(--ap-muted);
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Responsive */
   @media (max-width: 480px) {
     .audio-player__cover {

--- a/src/media/ImageGallery.astro
+++ b/src/media/ImageGallery.astro
@@ -143,8 +143,6 @@ const gallerySchema = {
   ))}
 </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
 {/* Lightbox Modal */}
 {lightbox && (
   <div
@@ -158,8 +156,6 @@ const gallerySchema = {
     <div class="lightbox__backdrop" data-lightbox-close></div>
 
     <div class="lightbox__content">
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Close Button */}
       <button
         type="button"
@@ -172,8 +168,6 @@ const gallerySchema = {
         </svg>
       </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Navigation */}
       <button
         type="button"
@@ -197,8 +191,6 @@ const gallerySchema = {
         </svg>
       </button>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Image Container */}
       <div class="lightbox__image-container">
         <img
@@ -213,8 +205,6 @@ const gallerySchema = {
         </div>
       </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
       {/* Caption & Counter */}
       <div class="lightbox__footer">
         <p class="lightbox__caption" data-lightbox-caption></p>
@@ -222,8 +212,6 @@ const gallerySchema = {
       </div>
     </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     {/* Images Data */}
     <script type="application/json" data-images>
       {JSON.stringify(images)}
@@ -232,8 +220,6 @@ const gallerySchema = {
 )}
 
 <style>
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Gallery Grid */
   .gallery {
     display: grid;
@@ -259,8 +245,6 @@ const gallerySchema = {
   .gallery--gap-md { gap: 1rem; }
   .gallery--gap-lg { gap: 1.5rem; }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Responsive columns */
   @media (max-width: 1024px) {
     .gallery--cols-5,
@@ -280,8 +264,6 @@ const gallerySchema = {
     .gallery--cols-6 { --columns: 2; }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Gallery Item */
   .gallery__item {
     margin: 0;
@@ -352,8 +334,6 @@ const gallerySchema = {
     text-align: center;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Lightbox */
   .lightbox {
     position: fixed;
@@ -386,8 +366,6 @@ const gallerySchema = {
     padding: 4rem 1rem 3rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Close Button */
   .lightbox__close {
     position: absolute;
@@ -416,8 +394,6 @@ const gallerySchema = {
     height: 1.5rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Navigation */
   .lightbox__nav {
     position: absolute;
@@ -459,8 +435,6 @@ const gallerySchema = {
     height: 1.5rem;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Image Container */
   .lightbox__image-container {
     position: relative;
@@ -504,8 +478,6 @@ const gallerySchema = {
     to { transform: rotate(360deg); }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Footer */
   .lightbox__footer {
     position: absolute;
@@ -531,8 +503,6 @@ const gallerySchema = {
     opacity: 0.7;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Animations */
   @keyframes fadeIn {
     from { opacity: 0; }
@@ -550,8 +520,6 @@ const gallerySchema = {
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Touch devices */
   @media (hover: none) {
     .lightbox__nav {

--- a/src/media/VideoPlayer.astro
+++ b/src/media/VideoPlayer.astro
@@ -124,8 +124,6 @@ const needsConsent = requireConsent && !isNative;
   data-needs-consent={needsConsent}
   style={`aspect-ratio: ${aspectRatio}; ${width ? `max-width: ${width}px;` : ''}`}
 >
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Native Video */}
   {isNative && src && (
     <video
@@ -146,8 +144,6 @@ const needsConsent = requireConsent && !isNative;
     </video>
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Third-party Video with Consent */}
   {!isNative && needsConsent && (
     <div class="video-player__consent" data-consent-screen>
@@ -186,8 +182,6 @@ const needsConsent = requireConsent && !isNative;
     </div>
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Third-party Video without Consent (or after consent) */}
   <div class="video-player__embed" data-embed-container hidden>
     {isYouTube && (
@@ -212,8 +206,6 @@ const needsConsent = requireConsent && !isNative;
     )}
   </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Play Button Overlay for native videos */}
   {isNative && !autoplay && (
     <button
@@ -238,8 +230,6 @@ const needsConsent = requireConsent && !isNative;
     overflow: hidden;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Native Video */
   .video-player__native {
     width: 100%;
@@ -247,8 +237,6 @@ const needsConsent = requireConsent && !isNative;
     object-fit: cover;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Consent Screen */
   .video-player__consent {
     position: relative;
@@ -331,8 +319,6 @@ const needsConsent = requireConsent && !isNative;
     opacity: 0.6;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Embed Container */
   .video-player__embed {
     position: absolute;
@@ -349,8 +335,6 @@ const needsConsent = requireConsent && !isNative;
     border: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Play Button Overlay */
   .video-player__play-btn {
     position: absolute;
@@ -378,8 +362,6 @@ const needsConsent = requireConsent && !isNative;
   .video-player__play-btn svg {
     width: 2rem;
     height: 2rem;
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
     margin-left: 0.25rem; /* Visual centering for play icon */
   }
 
@@ -387,8 +369,6 @@ const needsConsent = requireConsent && !isNative;
     display: none;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Responsive */
   @media (max-width: 480px) {
     .video-player__consent-content {

--- a/src/navigation/Breadcrumbs.astro
+++ b/src/navigation/Breadcrumbs.astro
@@ -180,8 +180,6 @@ const schemaData = {
     font-weight: 500;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Truncate on mobile */
   @media (max-width: 640px) {
     .breadcrumbs__item:not(:first-child):not(:last-child) {

--- a/src/ui/NewsTicker.astro
+++ b/src/ui/NewsTicker.astro
@@ -142,8 +142,6 @@ const duplicatedItems = [...items, ...items];
   aria-live="off"
   aria-label={label || 'News ticker'}
 >
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Label */}
   {label && (
     <div class="ticker-label absolute left-0 top-0 bottom-0 z-10 flex items-center px-4 font-semibold bg-inherit">
@@ -160,8 +158,6 @@ const duplicatedItems = [...items, ...items];
     </div>
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Controls */}
   {showControls && (
     <div class="ticker-controls absolute right-0 top-0 bottom-0 z-10 flex items-center gap-1 px-2 bg-inherit">
@@ -182,8 +178,6 @@ const duplicatedItems = [...items, ...items];
     </div>
   )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Ticker Track */}
   <div
     class:list={[
@@ -196,8 +190,6 @@ const duplicatedItems = [...items, ...items];
   >
     {duplicatedItems.map((item, index) => (
       <span class="ticker-item inline-flex items-center">
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Separator (except for first item in each set) */}
         {separator && index > 0 && (
           <span class:list={['ticker-separator mx-4', styles.separator]} aria-hidden="true">
@@ -205,8 +197,6 @@ const duplicatedItems = [...items, ...items];
           </span>
         )}
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
         {/* Item content */}
         {item.href ? (
           <a
@@ -244,8 +234,6 @@ const duplicatedItems = [...items, ...items];
     ))}
   </div>
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   {/* Gradient fade edges */}
   <div class:list={[
     'ticker-fade-left absolute left-0 top-0 bottom-0 w-8 pointer-events-none',
@@ -279,16 +267,12 @@ const duplicatedItems = [...items, ...items];
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Pause on hover */
   .news-ticker[data-pause-on-hover="true"]:hover .ticker-track,
   .news-ticker.paused .ticker-track {
     animation-play-state: paused;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* RTL support */
   [dir="rtl"] .ticker-track {
     animation-name: ticker-scroll-rtl;
@@ -303,8 +287,6 @@ const duplicatedItems = [...items, ...items];
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .ticker-track {
@@ -319,8 +301,6 @@ const duplicatedItems = [...items, ...items];
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Paused state icons */
   .news-ticker.paused .ticker-icon-pause {
     display: none;
@@ -330,8 +310,6 @@ const duplicatedItems = [...items, ...items];
     display: block;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Pulse animation for urgent */
   @keyframes ticker-pulse {
     0%, 100% {
@@ -346,8 +324,6 @@ const duplicatedItems = [...items, ...items];
     animation: ticker-pulse 2s ease-in-out infinite;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Gradient animation */
   .news-ticker .bg-gradient-to-r {
     background-size: 200% 100%;
@@ -363,8 +339,6 @@ const duplicatedItems = [...items, ...items];
     }
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Focus styles for links */
   .ticker-link:focus-visible {
     outline: 2px solid currentColor;
@@ -372,8 +346,6 @@ const duplicatedItems = [...items, ...items];
     border-radius: 2px;
   }
 
- * @copyright 2007-2026 Arnold Wender · Wender Media. All Rights Reserved. License: LicenseRef-Wender-Media-Source-1.0
- * @see https://github.com/arnoldwender/wm-project-astro-components
   /* Label gradient fade */
   .ticker-label::after {
     content: '';


### PR DESCRIPTION
## Critical bug — 12 components fail to compile

A license-injection build step dumped the `@copyright`/`@see` banner into the **template body** (not a comment) of 12 components, producing bare `* @copyright …` lines in `.astro` markup → `CompilerError: Unexpected token`. Any consumer importing those barrels (media, ecommerce, ui, images, navigation, content) gets a broken build.

**Affected (injected-line count):** AudioPlayer(26), ImageGallery(17), ProductCard(17), NewsTicker(15), VideoPlayer(11), ProductQuickView(11), Cart(9), Wishlist(8), AddToCartButton(8), OptimizedImage(5), Breadcrumbs(2), ShareBar(2).

## Fix

Stripped the injected `* @copyright/@see` lines from template bodies (the legitimate frontmatter banner is untouched). `astro check`: **0 errors** (was failing). Bump 4.0.1 → 4.0.2.

Found by the WM Studio nuclear hackaton (the live preview force-compiles every component).