### PR TITLE
[Fix] Repair the dependency declarations of all 8 shipped bundles (v4.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 4.1.1
+
+### Patch Changes
+
+- Fix the dependency declarations of all 8 shipped bundles — every one of them failed
+  `npm install`.
+
+  `bundles/` is listed in `files`, so these templates go out in the npm tarball. Each declared
+  `astro@^7.1.3` while pinning integrations from the Astro 5/6 era, and two of the pinned
+  versions **were never published at all**:
+
+  | Package              | Was       | Now       | Why it failed                                                    |
+  | -------------------- | --------- | --------- | ---------------------------------------------------------------- |
+  | `@astrojs/sitemap`   | `^4.0.0`  | `^3.7.3`  | no 4.x exists on any dist-tag — registry returns 404 (`ETARGET`) |
+  | `@astrojs/partytown` | `^3.0.0`  | `^2.1.7`  | no 3.x exists — max is 2.1.7 (`ETARGET`)                         |
+  | `@astrojs/mdx`       | `^5.0.0`  | `^7.0.0`  | v5 peers `astro@^6.0.0` (`ERESOLVE`)                             |
+  | `@astrojs/starlight` | `^0.39.1` | `^0.41.7` | 0.39.1 peers `astro@^6.0.0` (`ERESOLVE`)                         |
+  | `@astrojs/svelte`    | `^7.0.0`  | `^9.0.0`  | v7 peers `astro@^5.0.0` — two majors behind                      |
+  | `@astrojs/react`     | `^5.0.0`  | `^6.0.0`  | no astro peer either way; version debt only                      |
+
+  Affected: `affiliate`, `blog`, `corporate`, `docs`, `ecommerce`, `landing`, `portfolio`,
+  `saas` — all of them.
+
+  **Verification.** `npm install --dry-run` now resolves in all 8 bundles (was 0/8).
+  Mutation-checked rather than assumed: restoring the old declarations puts `landing` back to
+  `ETARGET` and `docs` back to `ERESOLVE`, so the check genuinely detects the defect.
+
+  The bundles stay on `typescript@^5.0.0`. `@astrojs/svelte@9` accepts `^5.3.3 || ^6.0.0`, and a
+  consumer template should not force a TypeScript major.
+
 ## 4.1.0
 
 ### Minor Changes

--- a/bundles/affiliate/package.json
+++ b/bundles/affiliate/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/mdx": "^5.0.0",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/partytown": "^3.0.0",
+    "@astrojs/mdx": "^7.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/partytown": "^2.1.7",
     "@astrojs/cloudflare": "^14.0.0",
     "@tailwindcss/vite": "^4.2.4",
     "tailwindcss": "^4.2.4"

--- a/bundles/blog/package.json
+++ b/bundles/blog/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/mdx": "^5.0.0",
+    "@astrojs/mdx": "^7.0.0",
     "@astrojs/rss": "^4.0.0",
-    "@astrojs/sitemap": "^4.0.0",
+    "@astrojs/sitemap": "^3.7.3",
     "@tailwindcss/vite": "^4.2.4",
     "tailwindcss": "^4.2.4"
   },
@@ -20,8 +20,8 @@
     "typescript": "^5.0.0"
   },
   "optionalDependencies": {
-    "@astrojs/react": "^5.0.0",
-    "@astrojs/partytown": "^3.0.0",
+    "@astrojs/react": "^6.0.0",
+    "@astrojs/partytown": "^2.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/bundles/corporate/package.json
+++ b/bundles/corporate/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/mdx": "^5.0.0",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/react": "^5.0.0",
+    "@astrojs/mdx": "^7.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/react": "^6.0.0",
     "@astrojs/netlify": "^8.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/bundles/docs/package.json
+++ b/bundles/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/starlight": "^0.39.1",
+    "@astrojs/starlight": "^0.41.7",
     "sharp": "^0.35.3"
   },
   "devDependencies": {

--- a/bundles/ecommerce/package.json
+++ b/bundles/ecommerce/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/react": "^5.0.0",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/partytown": "^3.0.0",
+    "@astrojs/react": "^6.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/partytown": "^2.1.7",
     "@astrojs/vercel": "^11.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/bundles/landing/package.json
+++ b/bundles/landing/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/partytown": "^3.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/partytown": "^2.1.7",
     "@tailwindcss/vite": "^4.2.4",
     "tailwindcss": "^4.2.4"
   },

--- a/bundles/portfolio/package.json
+++ b/bundles/portfolio/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/svelte": "^7.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/svelte": "^9.0.0",
     "svelte": "^5.0.0",
     "@tailwindcss/vite": "^4.2.4",
     "tailwindcss": "^4.2.4",

--- a/bundles/saas/package.json
+++ b/bundles/saas/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "@astrojs/react": "^5.0.0",
-    "@astrojs/sitemap": "^4.0.0",
-    "@astrojs/mdx": "^5.0.0",
+    "@astrojs/react": "^6.0.0",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/mdx": "^7.0.0",
     "@astrojs/vercel": "^11.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wendermedia/astro-components",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "LicenseRef-Wender-Media-Source-1.0",
       "bin": {
         "create-wm-component": "cli/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Complete Astro 7 development resource - components, bundles, integrations, and utilities",
   "type": "module",
   "main": "./index.ts",


### PR DESCRIPTION
## The defect

`bundles/` is listed in `files`, so all 8 bundle templates ship inside the npm tarball.
Every one of them declared `astro@^7.1.3` while pinning integrations from the Astro 5/6
era — and two of those pins point at versions that **were never published**.

Result: a consumer who copies any bundle and installs gets `ETARGET` or `ERESOLVE`.
Dry-run resolution succeeded in **0 of 8** bundles before this PR.

| Package | Was | Now | Failure |
|---|---|---|---|
| `@astrojs/sitemap` | `^4.0.0` | `^3.7.3` | no 4.x on any dist-tag; registry returns 404 — **`ETARGET`** |
| `@astrojs/partytown` | `^3.0.0` | `^2.1.7` | no 3.x exists, max is 2.1.7 — **`ETARGET`** |
| `@astrojs/mdx` | `^5.0.0` | `^7.0.0` | v5 peers `astro@^6.0.0` — **`ERESOLVE`** |
| `@astrojs/starlight` | `^0.39.1` | `^0.41.7` | 0.39.1 peers `astro@^6.0.0` — **`ERESOLVE`** |
| `@astrojs/svelte` | `^7.0.0` | `^9.0.0` | v7 peers `astro@^5.0.0`, two majors behind |
| `@astrojs/react` | `^5.0.0` | `^6.0.0` | no astro peer either way; version debt only |

Every target was checked against the live registry on 2026-08-12.

## Per bundle

| Bundle | Fixed |
|---|---|
| `affiliate` | sitemap, partytown, mdx |
| `blog` | sitemap, partytown, mdx, react |
| `corporate` | sitemap, mdx, react |
| `docs` | starlight |
| `ecommerce` | sitemap, partytown, react |
| `landing` | sitemap, partytown |
| `portfolio` | sitemap, svelte |
| `saas` | sitemap, mdx, react |

`blog` also carried broken pins inside `optionalDependencies`, where npm swallows the
failure silently — the template advertised optional integrations that could never install.

## Verification

Dry-run resolution now succeeds in **8 of 8** (366 / 387 / 914 / 354 / 337 / 225 / 235 /
443 packages respectively).

Mutation-checked rather than assumed — putting the old declarations back makes the check
fail again, so it genuinely detects the defect:

- `landing` reverted → `npm error code ETARGET`
- `docs` reverted → `npm error code ERESOLVE`

## Deliberately unchanged

Bundles stay on `typescript@^5.0.0`. `@astrojs/svelte@9` accepts `^5.3.3 || ^6.0.0`, and a
consumer template should not force a TypeScript major just because the library's own
toolchain moved to 6.