### PR TITLE
[Fix] Close a latent floor mismatch in bundles/affiliate (v4.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 4.1.2
+
+### Patch Changes
+
+- Fix a latent range mismatch in `bundles/affiliate` that resolves today only by luck.
+
+  The bundle declared `astro@^7.1.3` next to `@astrojs/cloudflare@^14.0.0`. That pair installs
+  right now because `astro` floats to 7.2.1 and `@astrojs/cloudflare` floats to 14.2.1 — but the
+  **floors** of the two declared ranges are incompatible: `@astrojs/cloudflare@14.2.1` peers
+  `astro@^7.2.0`, so pinning `astro` at 7.1.3 (the floor of its own declared range) fails with
+  `ERESOLVE`. Any lockfile, dedupe or `--prefer-offline` that lands astro on 7.1.x breaks the
+  bundle.
+
+  `@astrojs/cloudflare@^14.0.0` is also **not homogeneous**: 14.0.0 peers `astro@^7.0.0-alpha.2`
+  while 14.2.1 peers `astro@^7.2.0`. A caret range is not one constraint — the `.0` release of an
+  `@astrojs/*` major routinely ships a prerelease-tagged astro peer that later patches tighten.
+
+  Now `astro@^7.2.0` + `@astrojs/cloudflare@^14.2.0`, verified to resolve both at the exact
+  floors (7.2.0 + 14.2.0) and as declared. The other 7 bundles were checked with the same
+  floor-against-floor rule and came back coherent.
+
 ## 4.1.1
 
 ### Patch Changes

--- a/bundles/affiliate/package.json
+++ b/bundles/affiliate/package.json
@@ -9,11 +9,11 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^7.1.3",
+    "astro": "^7.2.0",
     "@astrojs/mdx": "^7.0.0",
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/partytown": "^2.1.7",
-    "@astrojs/cloudflare": "^14.0.0",
+    "@astrojs/cloudflare": "^14.2.0",
     "@tailwindcss/vite": "^4.2.4",
     "tailwindcss": "^4.2.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wendermedia/astro-components",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "LicenseRef-Wender-Media-Source-1.0",
       "bin": {
         "create-wm-component": "cli/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wendermedia/astro-components",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Complete Astro 7 development resource - components, bundles, integrations, and utilities",
   "type": "module",
   "main": "./index.ts",


### PR DESCRIPTION
Follow-up to #40. That PR made all 8 bundles resolve; a floor-against-floor re-check found
one pair that resolves **only because both sides float**.

## The defect

`bundles/affiliate` declared `astro@^7.1.3` next to `@astrojs/cloudflare@^14.0.0`.

- As written it installs — astro floats to 7.2.1, cloudflare to 14.2.1 (366 packages, exit 0).
- Pin `astro` to **7.1.3**, the floor of its *own declared range*, and it dies:
  `ERESOLVE / peer astro@"^7.2.0" from @astrojs/cloudflare@14.2.1`.

So any lockfile, dedupe or `--prefer-offline` that lands astro on 7.1.x breaks the bundle.
The declared pair was never coherent; it was masked by float.

## The general rule this exposes

**A range pair is only safe when the FLOOR of each range satisfies the other.** Checking the
resolved versions proves nothing about what a consumer's lockfile will pick.

And a caret range is not one constraint — `@astrojs/cloudflare@^14.0.0` is **not homogeneous**:

| version | `peerDependencies.astro` |
|---|---|
| 14.0.0 | `^7.0.0-alpha.2` |
| 14.2.1 | `^7.2.0` |

The `.0` release of an `@astrojs/*` major routinely ships a prerelease-tagged astro peer that
later patches tighten. The same shape was confirmed on `@astrojs/mdx` (5.0.0 → `^6.0.0-alpha.0`,
5.0.1+ → `^6.0.0`) and `@astrojs/svelte` (9.0.0 → `^7.0.0-alpha.0`, only 9.0.1 → `^7.0.0`).

## Fix

`astro@^7.2.0` + `@astrojs/cloudflare@^14.2.0`. Verified to resolve **at the exact floors**
(`astro@7.2.0` + `@astrojs/cloudflare@14.2.0` → 366 packages, exit 0) and as declared.

The other 7 bundles were re-checked with the same floor-against-floor rule across every
`@astrojs/*` entry in all four dependency blocks — all coherent, no changes needed.