### PR TITLE
[Chore] Declare bin paths without the leading ./ to silence a misleading publish warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "./index.ts",
   "bin": {
-    "create-wm-component": "./cli/bin.js",
-    "wm-components": "./cli/bin.js"
+    "create-wm-component": "cli/bin.js",
+    "wm-components": "cli/bin.js"
   },
   "exports": {
     ".": "./index.ts",


### PR DESCRIPTION
Publishing printed this twice:

```
npm warn publish "bin[create-wm-component]" script name cli/bin.js was invalid and removed
```

**Nothing was ever removed.** `@npmcli/package-json/lib/normalize.js` emits that message whenever the normalised target differs from the declared one — `./cli/bin.js` normalises to `cli/bin.js` — and then assigns it anyway:

```js
if (binTarget !== pkg.bin[binKey]) {
  changes?.push(`"bin[${base}]" script name ${binTarget} was invalid and removed`)
}
pkg.bin[base] = binTarget   // ← reassigned regardless
```

Empirical proof it is cosmetic — the **already-published 4.0.2** carries:

```json
{ "create-wm-component": "cli/bin.js", "wm-components": "cli/bin.js" }
```

So the CLI has always shipped fine. Declaring the normalised form directly yields byte-identical published metadata and removes a warning whose wording claims the opposite — which is a 20-minute detour for whoever reads the next publish log.

**Verified:** pack output no longer mentions `bin` at all, and `cli/bin.js` (2.0 kB) is still in the archive.

No version bump — the published `bin` value does not change.