### PR TITLE
[Docs] Document the lite-youtube optional peer and widen the TypeScript range

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [docs/MIGRATION-2.x-to-3.0.md](./docs/MIGRATION-2.x-to-3.0.md) for the full 
 
 - **Astro** 6.0 or higher
 - **Node.js** 22.12 or higher
-- **TypeScript** 5.x (recommended)
+- **TypeScript** 5.x or 6.x (recommended) &mdash; `astro check` is capped at 6.x by `@astrojs/check`
 
 ### Optional Peer Dependencies
 
@@ -86,6 +86,7 @@ See [docs/MIGRATION-2.x-to-3.0.md](./docs/MIGRATION-2.x-to-3.0.md) for the full 
 - `@astrojs/solid-js` &mdash; Solid island support
 - `@tailwindcss/vite` + `tailwindcss@^4` &mdash; styling for the templates
 - `GSAP` &mdash; Hero animations
+- `@justinribeiro/lite-youtube` &mdash; lazy-loaded YouTube embeds, imported on click by `LiteYouTubeEmbed` (`VideoPlayer` does not need it &mdash; it ships its own consent-gated `youtube-nocookie.com` embed)
 
 ## Installation
 


### PR DESCRIPTION
Two stale spots in the requirements section, both surfaced while reviewing #38.

## `@justinribeiro/lite-youtube` was undocumented

It is declared as an **optional peer** but never appeared in the Optional Peer Dependencies list. Now documented against the component that actually imports it — `LiteYouTubeEmbed` ([src/media/LiteYouTubeEmbed.astro:690](src/media/LiteYouTubeEmbed.astro#L690), dynamic `import()` on click).

The line also states explicitly that **`VideoPlayer` does not need it**. #38 proposed this same line but attributed it to `VideoPlayer`, which is incorrect: `VideoPlayer` ships its own consent-gated `youtube-nocookie.com` embed with `native | youtube | vimeo` providers and has zero references to lite-youtube. Merging that wording would have put a false statement in the README, so the corrected line lands here instead.

## `TypeScript 5.x` predated the 6.0.3 toolchain

Both majors work. The real ceiling is `@astrojs/check`, whose peer is `^5.0.0 || ^6.0.0` — so `astro check` cannot run under TypeScript 7. Now says `5.x or 6.x` with the reason, matching the banner chip (`TypeScript 5 · 6`) from #42.

No code, dependency or API change.