### PR TITLE
[Docs] Add contributor guides

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What changes
+
+<!-- One or two sentences. What does this do that the repository did not do before? -->
+
+## Why
+
+<!-- The problem, not the patch. If it fixes an issue, link it: Fixes #123 -->
+
+## How it was checked
+
+<!-- What you ran, and what it said. "Ran scripts/check.py, 0 failures" is enough.
+     If you could not check something, say which part — an honest gap is fine. -->
+
+## Notes for the reviewer
+
+<!-- Anything surprising: a decision you were unsure about, scope you deliberately left
+     out, or a follow-up you think is needed. Delete if there is nothing. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Use GitHub's private vulnerability reporting instead: go to the **Security** tab of this
+repository and choose *Report a vulnerability*. That opens a private channel visible only
+to the maintainer, and it lets the report be tracked and credited properly once it is
+fixed.
+
+Useful things to include, if you have them:
+
+- what an attacker can do, and what they need in order to do it
+- the steps to reproduce, or a minimal proof of concept
+- the version, commit, or environment where you observed it
+
+## What to expect
+
+This is a maintainer-hours project, not a funded programme — there is no response-time
+guarantee, and it would be dishonest to print one. Reports are read, and confirmed issues
+are fixed and disclosed once a fix exists.
+
+## Scope
+
+Anything in this repository. Findings in a third-party dependency should go to that
+project; if the dependency is reachable through this one in a way that makes the problem
+worse, it is worth reporting here too.


### PR DESCRIPTION
Adds the files someone arriving from a fork needs, and that none of these repositories had:

- **CONTRIBUTING.md** — fork, branch, PR against `main`, what makes a change easy to accept. (Left untouched where the repository already had one.)
- **CODE_OF_CONDUCT.md** — short and original, not a templated copy.
- **SECURITY.md** — points at GitHub private vulnerability reporting, which is now enabled on this repository, so the channel it documents actually exists.
- **.github/PULL_REQUEST_TEMPLATE.md** — what changed, why, and how it was checked.

`main` is protected: no direct pushes, pull request required, force-push and deletion blocked — for the maintainer too.