### PR TITLE
[Fix] netlify.toml — der Deploy suchte ein dist/, das dieses Repo nie erzeugt

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,23 @@
+# Build configuration for astro.wendermedia.com
+#
+# Dieses Repo ist eine Komponenten-Bibliothek (npm-Paket
+# @wendermedia/astro-components), KEINE Astro-Site: es gibt weder ein
+# `build`-Script noch eine astro.config.mjs, und damit auch kein dist/.
+# Was die Domain ausliefert, ist der Storybook-Showcase.
+#
+# Die UI-Einstellung stand auf `npm run tokens:build` mit publish `dist`.
+# tokens:build erzeugt nur die Design-Tokens unter tokens/dist/ — das
+# Verzeichnis dist/ entsteht dabei nie, deshalb brach der Deploy mit
+# "Deploy directory 'dist' does not exist" ab.
+#
+# Ein `netlify.toml` im Repo hat Vorrang vor der UI, damit die Einstellung
+# versioniert ist und nicht wieder still auseinanderlaeuft.
+
+[build]
+  # tokens:build zuerst — Storybook zieht die generierten Tokens.
+  command = "npm run tokens:build && npm run build-storybook"
+  publish = "storybook-static"
+
+[build.environment]
+  # package.json engines verlangt >=22.12.0
+  NODE_VERSION = "24"


### PR DESCRIPTION
Der Netlify-Build brach ab mit **`Deploy directory 'dist' does not exist`**.

## Warum der naheliegende Fix falsch gewesen waere

Die Fehlermeldung legt `npm run tokens:build && npm run build` nahe. Das schlaegt hier fehl:

```
package.json scripts:  test, storybook, build-storybook, tokens:build, banners, lint, format
                       ^ kein "build"
astro.config.mjs:      existiert nicht
```

Dieses Repo ist die **Komponenten-Bibliothek** (npm-Paket `@wendermedia/astro-components@4.1.2`), keine Astro-Site. Es gibt kein `dist/` zu erzeugen.

## Was die Domain tatsaechlich ausliefert

`astro.wendermedia.com` serviert den **Storybook-Showcase** — der Live-Stand vom 2026-04-06 traegt `<title>@storybook/core - Storybook</title>`. Die UI-Einstellung (`tokens:build` → `dist`) hat also nie zu dem gepasst, was online steht; sie erzeugt nur die Tokens unter `tokens/dist/`.

## Fix

```toml
[build]
  command = "npm run tokens:build && npm run build-storybook"
  publish = "storybook-static"
```

Als `netlify.toml` statt UI-Einstellung: die Datei hat Vorrang vor der UI, und damit ist die Konfiguration versioniert statt still driftend.

`tokens:build` bleibt vorgeschaltet, weil Storybook die generierten Tokens zieht.

## Verifikation

`storybook-static/` und `tokens/dist/` geloescht, dann der Zweischritt aus dem Nichts:

```
✔︎ tokens/dist/tokens.js
└ Storybook build completed successfully
storybook-static/  231 Dateien, index.html vorhanden
```